### PR TITLE
Add QTT-DFT

### DIFF
--- a/examples/dft/dft.jl
+++ b/examples/dft/dft.jl
@@ -1,0 +1,50 @@
+using ITensors
+using ITensorQTT
+using FFTW
+using UnicodePlots
+
+ITensors.disable_warn_order()
+
+function dft_matrix(n::Int)
+  N = 2^n
+  ω = exp(-2π * im / N)
+  return [ω^(j * k) / √N for j in 0:(N-1), k in 0:(N-1)]
+end
+
+n = 20
+s = siteinds("Qubit", n)
+
+println("\nMake DFT MPO")
+U = @time dft_mpo(s)
+@show maxlinkdim(U)
+
+@show norm(U - U_gates)
+
+if n ≤ 10
+  println("\nMake DFT Matrix")
+  dft_mat = @time dft_matrix(n)
+
+  println("\nConvert DFT MPO to Matrix")
+  U_mat = @time mpo_to_mat(U; reverse_output_sites=true)
+
+  println("\nCompare DFT MPO to DFT Matrix")
+  @show norm(U_mat - dft_mat)
+end
+
+ψ = +(qtt(sin, 2π, s), qtt(sin, 4π, s), qtt(sin, 8π, s), qtt(sin, 16π, s); alg="directsum")
+@show maxlinkdim(ψ)
+  
+println("\nApply DFT MPO")
+ψ̃ = @time reverse(apply(U, ψ; cutoff=1e-15))
+@show maxlinkdim(ψ̃)
+
+println("\nConvert MPS to Vector")
+f = @time mps_to_discrete_function(ψ)
+
+println("\nConvert Fourier transformed MPS to Vector")
+f̃ = @time mps_to_discrete_function(ψ̃)
+
+println("\nFFT")
+f̃_fft = @time fft(f) / √(2^n)
+
+@show norm(f̃_fft - f̃) / norm(f̃)

--- a/src/ITensorQTT.jl
+++ b/src/ITensorQTT.jl
@@ -20,12 +20,15 @@ include("laplacian.jl")
 include("evolve.jl")
 include("integration.jl")
 include("dmrg_target.jl")
+include("dft.jl")
 
 export function_to_mps,
   qtt_xrange,
   mps_to_discrete_function,
   mpo_to_mat,
   laplacian_mpo,
+  dft_mpo,
+  dft_circuit,
   integrate_mps,
   prolongate,
   retract,

--- a/src/dft.jl
+++ b/src/dft.jl
@@ -1,0 +1,100 @@
+"""
+    qft(n::Int; inverse::Bool = false)
+
+Generate a list of gates for the quantum fourier transform circuit on `n` qubits.
+"""
+function qft(N::Int; inverse::Bool=false)
+  circuit = []
+  if inverse
+    for j in N:-1:1
+      for k in N:-1:(j + 1)
+        angle = -π / 2^(k - j)
+        push!(circuit, ("CPHASE", (k, j), (ϕ=angle,)))
+      end
+      push!(circuit, ("H", j))
+    end
+  else
+    for j in 1:(N - 1)
+      push!(circuit, ("H", j))
+      for k in (j + 1):N
+        angle = -π / 2^(k - j)
+        push!(circuit, ("CPHASE", (k, j), (ϕ=angle,)))
+      end
+    end
+    push!(circuit, ("H", N))
+  end
+  return circuit
+end
+
+function dft_circuit(s::Vector{<:Index}; inverse::Bool=false)
+  return ops(qft(length(s); inverse), s)
+end
+
+function dft_matrix(n::Int)
+  N = 2^n
+  ω = exp(-2π * im / N)
+  return [ω^(j * k) / √N for j in 0:(N-1), k in 0:(N-1)]
+end
+
+function dft_mpo(s::Vector{<:Index}; alg="mpo", kwargs...)
+  return dft_mpo(Algorithm(alg), s; kwargs...)
+end
+
+# https://arxiv.org/pdf/2210.08468.pdf
+# Eq. 53-54
+function phase_mpo(s::Vector{<:Index})
+  n = length(s)
+  if n == 1
+    return MPO(s, "I")
+  end
+  U = MPO(n)
+  l = [Index(2; tags="l=$(n)↔$(n+1)") for n in 1:(n - 1)]
+  U[1] = δ(s[1], s[1]', l[1])
+  for j in 2:(n - 1)
+    U[j] = op("I", s[j]) * onehot(l[j - 1] => 1, l[j] => 1)
+    U[j] += op("Phase", s[j]; ϕ=-π/2^(j - 1)) * onehot(l[j - 1] => 2, l[j] => 2)
+  end
+  U[n] = op("I", s[n]) * onehot(l[n - 1] => 1)
+  U[n] += op("Phase", s[n]; ϕ=-π/2^(n - 1)) * onehot(l[n - 1] => 2)
+  return U
+end
+
+function hadamard_phase_mpo(s::Vector{<:Index})
+  U = phase_mpo(s)
+
+  H1 = op("H", s[1])
+  U[1] = apply(H1, U[1])
+  return U
+end
+
+function dft_mpo(::Algorithm"mpo", s::Vector{<:Index}; cutoff=1e-15)
+  n = length(s)
+  Us = Vector{MPO}(undef, n)
+  for j in 1:n
+    Ij = if j == 1
+      MPO(ITensor[])
+    else
+      # TODO: Implement for `length(s) == 0`?
+      MPO(s[1:(j - 1)], "I")
+    end
+    Uj = hadamard_phase_mpo(s[j:n])
+    Us[j] = [Ij; Uj]
+  end
+  U = Us[1]
+  for j in 2:n
+    U = apply(U, Us[j]; cutoff)
+  end
+  return swapprime(U, 0 => 1)
+end
+
+# Discrete Fourier transform MPO from QFT circuit
+# Faster to use `alg="mpo"`, not recommended.
+function dft_mpo(::Algorithm"circuit", s::Vector{<:Index};
+  inverse::Bool=false,
+  cutoff=1e-15,
+  move_sites_back_between_gates=true,
+  move_sites_back=true,
+)
+  return apply(dft_circuit(s; inverse), MPO(s, "I"); cutoff, move_sites_back_between_gates, move_sites_back)
+end
+

--- a/src/function_to_mps.jl
+++ b/src/function_to_mps.jl
@@ -149,9 +149,15 @@ end
 # Matrix/MPO conversion
 #
 
-function mpo_to_mat(m)
-  s = only.(siteinds(m; plev=0))
-  return reshape((Array(contract(m), reverse(s'), reverse(s))), dim(s), dim(s))
+function mpo_to_mat(m; reverse_input_sites=false, reverse_output_sites=false)
+  s_in = reverse(only.(siteinds(m; plev=0)))
+  s_out = s_in'
+
+  # Possible bit reversal
+  s_in = reverse_input_sites ? reverse(s_in) : s_in
+  s_out = reverse_output_sites ? reverse(s_out) : s_out
+
+  return reshape((Array(contract(m), s_out, s_in)), dim(s_out), dim(s_in))
 end
 
 function mat_to_mpo(m, s; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,2 +1,3 @@
 [deps]
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 ITensors = "9136182c-28ba-11e9-034c-db9fb085ebd5"


### PR DESCRIPTION
Add QTT-DFT.

The main interface is `dft_mpo(s::Vector{<:Index})`. This creates an MPO that, when applied to an MPS/QTT, returns the Fourier transformed version of the function represented by the MPS/QTT but with the bits reversed.

The default construction used in `dft_mpo` involves contracting `n` "phase MPOs" for an `n`-qubit system, based on Eq. 53-54 of https://arxiv.org/abs/2210.08468.