### PR TITLE
Add Fourier interpolation

### DIFF
--- a/examples/dft/fourier_interpolation.jl
+++ b/examples/dft/fourier_interpolation.jl
@@ -1,0 +1,30 @@
+using ITensors
+using ITensorQTT
+using FFTW
+using UnicodePlots
+
+n = 5
+s = siteinds("Qubit", n)
+
+x₀ = 0.5
+σ = 0.1
+f(x) = exp(-(x - x₀)^2 / σ^2)
+ψ = function_to_mps(f, s, 0.0, 1.0; cutoff=1e-15)
+ℱψ = apply_dft_mpo(ψ; cutoff=1e-15)
+ℱ⁻¹ℱψ = apply_idft_mpo(ℱψ; cutoff=1e-15)
+
+display(lineplot(mps_to_discrete_function(ψ); title="ψ"))
+display(lineplot(real(mps_to_discrete_function(ℱψ)); title="real(ℱψ)"))
+display(lineplot(imag(mps_to_discrete_function(ℱψ)); title="real(ℱψ)"))
+display(lineplot(real(mps_to_discrete_function(ℱ⁻¹ℱψ)); title="real(ℱ⁻¹ℱψ)"))
+
+@show norm(fft(mps_to_discrete_function(ψ)) / 2^(n/2) - mps_to_discrete_function(ℱψ))
+@show norm(ℱ⁻¹ℱψ - ψ)
+
+k = 3
+ψⁿ⁺ᵏ = fourier_interpolation(ψ, k; cutoff=1e-15)
+sⁿ⁺ᵏ = siteinds(ψⁿ⁺ᵏ)
+ψ̃ⁿ⁺ᵏ = function_to_mps(f, sⁿ⁺ᵏ, 0.0, 1.0; cutoff=1e-15)
+
+display(lineplot(real(mps_to_discrete_function(ψⁿ⁺ᵏ)); title="real(ψⁿ⁺ᵏ)"))
+@show norm(ψⁿ⁺ᵏ - ψ̃ⁿ⁺ᵏ)

--- a/src/ITensorQTT.jl
+++ b/src/ITensorQTT.jl
@@ -21,6 +21,7 @@ include("evolve.jl")
 include("integration.jl")
 include("dmrg_target.jl")
 include("dft.jl")
+include("fourier_interpolation.jl")
 
 export function_to_mps,
   qtt_xrange,
@@ -28,6 +29,8 @@ export function_to_mps,
   mpo_to_mat,
   laplacian_mpo,
   dft_mpo,
+  fourier_interpolation,
+  repeat_function,
   dft_circuit,
   integrate_mps,
   prolongate,
@@ -48,6 +51,8 @@ export function_to_mps,
   sqeuclidean,
   sqeuclidean_normalized,
   vec_to_mps,
-  siteinds_per_dimension
+  siteinds_per_dimension,
+  apply_dft_mpo,
+  apply_idft_mpo
 
 end

--- a/src/fourier_interpolation.jl
+++ b/src/fourier_interpolation.jl
@@ -1,0 +1,38 @@
+function fourier_interpolation(ψ::MPS, s_interp::Vector{<:Index}; cutoff=1e-15)
+  s = siteinds(ψ)
+  ℱψ = apply_dft_mpo(ψ; cutoff)
+  ℱψ0 = project_bits(ℱψ, [0])
+  ℱψ1 = project_bits(ℱψ, [1])
+  ℱψ0s = [[onehot.(s_interp .=> "0"); onehot(s[1] => "0")]; ℱψ0]
+  ℱψ1s = [[onehot.(s_interp .=> "1"); onehot(s[1] => "1")]; ℱψ1]
+  ℱψ_interp = +(ℱψ0s, ℱψ1s; cutoff=1e-15)
+  return apply_idft_mpo(ℱψ_interp; cutoff) * 2^(length(s_interp)/2)
+end
+
+"""
+Fourier interpolation of MPS/QTT from https://arxiv.org/abs/1909.06619
+Interpolate an MPS/QTT ψ of length `n` to an MPS/QTT of length
+`n + k`.
+"""
+function fourier_interpolation(ψ::MPS, k::Int=1; kwargs...)
+  return fourier_interpolation(ψ, siteinds("Qubit", k); kwargs...)
+end
+
+function repeat_function(ψ::MPS, sₖ::Vector{<:Index}; cutoff=1e-15)
+  s = siteinds(ψ)
+  n = length(s)
+  k = length(sₖ)
+  ℱψ = apply_dft_mpo(ψ; cutoff)
+  # Insert qubits in position 1:k
+  sₙ₊ₖ = [sₖ; s]
+  ℱψₖ = iszero(k) ? MPS(ITensor[]) : MPS(sₖ, "0")
+  ℱψₙ₊ₖ = [ℱψ; ℱψₖ]
+  return apply_idft_mpo(ℱψₙ₊ₖ; cutoff) * 2^(length(sₖ)/2)
+end
+
+"""
+Repeat a function `2ᵏ` times.
+"""
+function repeat_function(ψ::MPS, k::Int; cutoff=1e-15)
+  return repeat_function(ψ, siteinds("Qubit", k); cutoff)
+end

--- a/src/mps_utils.jl
+++ b/src/mps_utils.jl
@@ -2,9 +2,11 @@ normalized_inner(x, y) = inner(x, y) / (norm(x) * norm(y))
 
 # TODO: Move to ITensors.jl
 using ITensors: AbstractMPS
-Base.vcat(a::ITensor, ψ::AbstractMPS) = typeof(ψ)([a; ITensors.data(ψ)])
-Base.vcat(ψ::AbstractMPS, a::ITensor) = typeof(ψ)([ITensors.data(ψ); a])
 Base.vcat(ψ₁::MPST, ψ₂::MPST) where {MPST<:AbstractMPS} = MPST([ITensors.data(ψ₁); ITensors.data(ψ₂)])
+Base.vcat(a::ITensor, ψ::AbstractMPS) = [typeof(ψ)([a]); ψ]
+Base.vcat(a::Vector{ITensor}, ψ::AbstractMPS) = [typeof(ψ)(a); ψ]
+Base.vcat(ψ::AbstractMPS, a::ITensor) = [ψ; typeof(ψ)([a])]
+Base.vcat(ψ::AbstractMPS, a::Vector{ITensor}) = [ψ; typeof(ψ)(a)]
 Base.reverse(ψ::AbstractMPS) = typeof(ψ)(reverse(ITensors.data(ψ)))
 Base.pop!(ψ::AbstractMPS) = pop!(ITensors.data(ψ))
 
@@ -132,4 +134,12 @@ end
 function sqeuclidean_normalized(x::Vector, y::Vector)
   yy = dot(y, y)
   return 1.0 + (dot(x, x) / yy - 2 * real(dot(y, x)) / yy)
+end
+
+function ITensors.replaceinds(M::AbstractMPS, inds_replacement::Vector{<:Pair})
+  M = copy(M)
+  for j in 1:length(M)
+    M[j] = replaceinds(M[j], inds_replacement[j])
+  end
+  return M
 end


### PR DESCRIPTION
Add the function `fourier_interpolation(psi::MPS, k::Int)` that implements Fourier interpolation (Section 5.2.2 of https://arxiv.org/abs/1909.06619) to improve on the currently available linear interpolation available through the function `prolongate`. This is performed by performing a Fourier transform, appending high-frequency qubits set to zero, and then performing an inverse Fourier transform in the enlarged Hilbert space.